### PR TITLE
FIX spelling fix in EuiInputComboTable

### DIFF
--- a/Facades/Elements/EuiInputComboTable.php
+++ b/Facades/Elements/EuiInputComboTable.php
@@ -300,7 +300,7 @@ JS;
         // of values.
         $value = $widget->getValueWithDefaults();
         $valueJs = null;
-        if ($value !== nul && $value !== '') {
+        if ($value !== null && $value !== '') {
             if (! $widget->getMultiSelect()) {
                 $valueJs = $this->escapeString($value);
             } else {


### PR DESCRIPTION
- fixed a spelling mistake in EuiInputComboTable (used 'nul' instead of 'null' before)